### PR TITLE
Test existence of files in include dir

### DIFF
--- a/configure-as-labmachine.sh
+++ b/configure-as-labmachine.sh
@@ -28,7 +28,7 @@ source /etc/os-release
 normalize_distro_names
 
 source ${CONFIG_DIR}/configure-as-labmachine.cfg
-source ${INCLUDE_DIR}/*.sh
+[ -f ${INCLUDE_DIR}/*.sh ] && source ${INCLUDE_DIR}/*.sh
 
 #############################################################################
 


### PR DESCRIPTION
If there's no *.sh in the directory it produces an error so it needs to test for files first.